### PR TITLE
Add dramatic dark preloader and glowing navigation

### DIFF
--- a/src/components/Loader.tsx
+++ b/src/components/Loader.tsx
@@ -3,37 +3,45 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import { AnimatePresence, motion } from 'framer-motion'
 import Image from 'next/image'
 import styles from '@/styles/components.module.css'
 
 export default function Loader() {
-  const [isLoading, setIsLoading] = useState(true)
+  const [show, setShow] = useState(true)
 
   useEffect(() => {
-    const timer = setTimeout(() => {
-      setIsLoading(false)
-    }, 2000) // Match this with the fade duration
-
+    const timer = setTimeout(() => setShow(false), 2600)
     return () => clearTimeout(timer)
   }, [])
 
   return (
-    <div className={`${styles.loaderContainer} ${isLoading ? '' : styles['fade-out']}`}>
-      <div className={styles.loaderLogo}>
-        <div className={styles.circleOuter}></div>
-        <div className={styles.circleInner}></div>
-        <div className={styles.loaderIconImage}>
-          <Image 
-            src="/logo.png" 
-            alt="Hyder Electrical Logo" 
-            width={120}
-            height={130}
-            priority
-            style={{ width: 'auto', height: '100%' }}
-          />
-        </div>
-        <div className={styles.loaderText}>Hyder Electrical</div>
-      </div>
-    </div>
+    <AnimatePresence>
+      {show && (
+        <motion.div
+          className={styles.loaderContainer}
+          initial={{ opacity: 1 }}
+          animate={{ opacity: 0, transition: { duration: 1.4, delay: 1.2 } }}
+          exit={{ opacity: 0 }}
+        >
+          <div className={styles.loaderLogo}>
+            <span className={styles.lightSweep} />
+            <div className={styles.circleOuter}></div>
+            <div className={styles.circleInner}></div>
+            <div className={styles.loaderIconImage}>
+              <Image
+                src="/logo.png"
+                alt="Hyder Electrical Logo"
+                width={120}
+                height={130}
+                priority
+                style={{ width: 'auto', height: '100%' }}
+              />
+            </div>
+            <div className={styles.loaderText}>Hyder Electrical</div>
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
   )
 }

--- a/src/styles/components.module.css
+++ b/src/styles/components.module.css
@@ -7,11 +7,12 @@
   left: 0;
   width: 100%;
   height: 100vh;
-  background: radial-gradient(circle at center, var(--dark-navy) 0%, var(--midnight) 100%);
+  background: #000;
   display: flex;
   justify-content: center;
   align-items: center;
   z-index: 10000;
+  overflow: hidden;
   transition: opacity 1.5s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
@@ -27,6 +28,17 @@
   display: flex;
   justify-content: center;
   align-items: center;
+}
+
+.lightSweep {
+  position: absolute;
+  top: 0;
+  left: -150%;
+  width: 50%;
+  height: 100%;
+  background: rgba(255, 255, 255, 0.08);
+  transform: skewX(-20deg);
+  animation: sweep 1.5s ease-in-out 0.4s forwards;
 }
 
 .circleOuter {
@@ -79,6 +91,12 @@
   }
 }
 
+@keyframes sweep {
+  to {
+    left: 150%;
+  }
+}
+
 .lightningBolt {
   position: absolute;
   width: 60px;
@@ -118,6 +136,23 @@
   to {
     opacity: 1;
     transform: translateX(-50%) translateY(-10px);
+  }
+}
+
+@media (max-width: 480px) {
+  .loaderLogo {
+    width: 180px;
+    height: 180px;
+  }
+
+  .circleOuter {
+    width: 120px;
+    height: 120px;
+  }
+
+  .circleInner {
+    width: 80px;
+    height: 80px;
   }
 }
 
@@ -237,11 +272,21 @@
 .navLink:hover,
 .navLink.active {
   color: var(--gold);
+  animation: electric-glow 1.5s ease-in-out infinite alternate;
 }
 
 .navLink:hover::after,
 .navLink.active::after {
   width: 100%;
+}
+
+@keyframes electric-glow {
+  from {
+    text-shadow: 0 0 4px rgba(212, 175, 55, 0.4), 0 0 10px rgba(212, 175, 55, 0.2);
+  }
+  to {
+    text-shadow: 0 0 12px rgba(212, 175, 55, 0.8), 0 0 24px rgba(255, 255, 255, 0.6);
+  }
 }
 
 .mobileMenuBtn {
@@ -1400,14 +1445,6 @@
 }
 
 /* ======== TRANSITION ANIMATIONS — FADE FROM PRELOADER TO PAGE ======== */
-
-/* Fade out preloader */
-.loaderContainer.fade-out {
-  opacity: 0;
-  pointer-events: none;
-  transform: scale(1.05); /* Slight zoom-out for cinematic feel */
-  transition: opacity 1.4s ease-out, transform 1.4s ease-out, background 1.4s ease-out;
-}
 
 /* Fade in main content after preloader */
 .main-container {


### PR DESCRIPTION
## Summary
- Replace basic loader with animated framer-motion preloader that fades from black with a sweeping light
- Tweak responsive loader sizing for mobile devices
- Give navigation links an electrical glow on hover and active states

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(requires interactive setup; no lint run)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68c5162c2cd08329acbbb0f0a311283f