### PR TITLE
Enhance preloader with circuit board animation and refreshed hero

### DIFF
--- a/public/circuit-board.svg
+++ b/public/circuit-board.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 500">
+  <g stroke="#d4af37" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M20 250h120v-80h100v160h120" />
+    <path d="M140 170v-90h100" />
+    <path d="M240 80v90h80" />
+    <path d="M320 260v-90h100" />
+    <circle cx="20" cy="250" r="5" fill="#d4af37" />
+    <circle cx="140" cy="170" r="5" fill="#d4af37" />
+    <circle cx="140" cy="250" r="5" fill="#d4af37" />
+    <circle cx="240" cy="80" r="5" fill="#d4af37" />
+    <circle cx="240" cy="170" r="5" fill="#d4af37" />
+    <circle cx="320" cy="170" r="5" fill="#d4af37" />
+    <circle cx="320" cy="260" r="5" fill="#d4af37" />
+    <circle cx="440" cy="260" r="5" fill="#d4af37" />
+  </g>
+</svg>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,13 +8,11 @@ export default function Home() {
     <div className={styles.page}>
       <section className={styles.heroSection}>
         <div className={styles.heroContent}>
-          <div className={styles.heroSubtitle}>Excellence in Contracting</div>
-          <h1 className={styles.heroTitle}>Taking You Out of the Dark</h1>
+          <div className={styles.heroSubtitle}>Turnkey Electrical Engineering</div>
+          <h1 className={styles.heroTitle}>Bringing Power Out of the Dark</h1>
           <p className={styles.heroDescription}>
-            An Electrical Turnkey Company,
-            that offer a turnkey design from initial Design to completed projects,
-            specializing in high-end commercial, industrial, and infrastructure projects 
-            across South Africa. With over 33 years of excellence, we illuminate possibilities.
+            From CAD precision to electrified reality, our end-to-end solutions light the path for
+            hospitals, industries, and infrastructure across South Africa.
           </p>
           <Link href="/contact" className={styles.luxuryButton}>
             Begin Your Project

--- a/src/components/Loader.tsx
+++ b/src/components/Loader.tsx
@@ -3,37 +3,97 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import { AnimatePresence, motion } from 'framer-motion'
 import Image from 'next/image'
 import styles from '@/styles/components.module.css'
 
 export default function Loader() {
-  const [isLoading, setIsLoading] = useState(true)
+  const [show, setShow] = useState(true)
 
   useEffect(() => {
-    const timer = setTimeout(() => {
-      setIsLoading(false)
-    }, 2000) // Match this with the fade duration
-
+    const timer = setTimeout(() => setShow(false), 4400)
     return () => clearTimeout(timer)
   }, [])
 
   return (
-    <div className={`${styles.loaderContainer} ${isLoading ? '' : styles['fade-out']}`}>
-      <div className={styles.loaderLogo}>
-        <div className={styles.circleOuter}></div>
-        <div className={styles.circleInner}></div>
-        <div className={styles.loaderIconImage}>
-          <Image 
-            src="/logo.png" 
-            alt="Hyder Electrical Logo" 
-            width={120}
-            height={130}
-            priority
-            style={{ width: 'auto', height: '100%' }}
-          />
-        </div>
-        <div className={styles.loaderText}>Hyder Electrical</div>
-      </div>
-    </div>
+    <AnimatePresence>
+      {show && (
+        <motion.div
+          className={styles.loaderContainer}
+          initial={{ opacity: 1 }}
+          animate={{ opacity: 0, transition: { duration: 1.4, delay: 3 } }}
+          exit={{ opacity: 0 }}
+        >
+          <div className={styles.loaderLogo}>
+            <span className={styles.lightSweep} />
+            <div className={styles.circleOuter}></div>
+            <div className={styles.circleInner}></div>
+            <motion.svg
+              className={styles.circuitBoard}
+              viewBox="0 0 200 200"
+            >
+              <motion.path
+                d="M10 150h60v-40h40v-40h80"
+                stroke="var(--copper)"
+                strokeWidth="2"
+                fill="none"
+                strokeLinecap="round"
+                initial={{ pathLength: 0 }}
+                animate={{ pathLength: 1 }}
+                transition={{ duration: 2.2, ease: 'easeInOut' }}
+              />
+              <motion.circle
+                cx="10"
+                cy="150"
+                r="3"
+                fill="var(--gold)"
+                initial={{ opacity: 0, scale: 0 }}
+                animate={{ opacity: 1, scale: 1 }}
+                transition={{ delay: 1 }}
+              />
+              <motion.circle
+                cx="70"
+                cy="110"
+                r="3"
+                fill="var(--gold)"
+                initial={{ opacity: 0, scale: 0 }}
+                animate={{ opacity: 1, scale: 1 }}
+                transition={{ delay: 1.2 }}
+              />
+              <motion.circle
+                cx="110"
+                cy="70"
+                r="3"
+                fill="var(--gold)"
+                initial={{ opacity: 0, scale: 0 }}
+                animate={{ opacity: 1, scale: 1 }}
+                transition={{ delay: 1.4 }}
+              />
+              <motion.circle
+                cx="190"
+                cy="70"
+                r="3"
+                fill="var(--gold)"
+                initial={{ opacity: 0, scale: 0 }}
+                animate={{ opacity: 1, scale: 1 }}
+                transition={{ delay: 1.6 }}
+              />
+            </motion.svg>
+            <div className={styles.loaderIconImage}>
+              <Image
+                src="/logo.png"
+                alt="Hyder Electrical Logo"
+                width={120}
+                height={130}
+                priority
+                style={{ width: 'auto', height: '100%' }}
+              />
+            </div>
+            <div className={styles.loaderText}>Hyder Electrical</div>
+            <div className={styles.loaderTagline}>Engineering Power Out of the Dark</div>
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
   )
 }

--- a/src/styles/components.module.css
+++ b/src/styles/components.module.css
@@ -7,11 +7,12 @@
   left: 0;
   width: 100%;
   height: 100vh;
-  background: radial-gradient(circle at center, var(--dark-navy) 0%, var(--midnight) 100%);
+  background: #000;
   display: flex;
   justify-content: center;
   align-items: center;
   z-index: 10000;
+  overflow: hidden;
   transition: opacity 1.5s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
@@ -27,6 +28,17 @@
   display: flex;
   justify-content: center;
   align-items: center;
+}
+
+.lightSweep {
+  position: absolute;
+  top: 0;
+  left: -150%;
+  width: 50%;
+  height: 100%;
+  background: rgba(255, 255, 255, 0.08);
+  transform: skewX(-20deg);
+  animation: sweep 1.5s ease-in-out 0.4s forwards;
 }
 
 .circleOuter {
@@ -47,6 +59,13 @@
   border-radius: 50%;
   animation: pulse-rotate-reverse 2s linear infinite;
   box-shadow: inset 0 0 30px rgba(184, 115, 51, 0.2);
+}
+
+.circuitBoard {
+  position: absolute;
+  width: 260px;
+  height: 260px;
+  opacity: 0.2;
 }
 
 @keyframes pulse-rotate {
@@ -76,6 +95,12 @@
   100% {
     transform: rotate(0deg) scale(1);
     opacity: 0.6;
+  }
+}
+
+@keyframes sweep {
+  to {
+    left: 150%;
   }
 }
 
@@ -114,10 +139,42 @@
   animation: fadeInUp 1s ease 0.5s forwards;
 }
 
+.loaderTagline {
+  white-space: nowrap;
+  position: absolute;
+  bottom: -100px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-family: var(--font-playfair);
+  font-size: 16px;
+  letter-spacing: 4px;
+  color: var(--secondary);
+  text-transform: uppercase;
+  opacity: 0;
+  animation: fadeInUp 1s ease 1.5s forwards;
+}
+
 @keyframes fadeInUp {
   to {
     opacity: 1;
     transform: translateX(-50%) translateY(-10px);
+  }
+}
+
+@media (max-width: 480px) {
+  .loaderLogo {
+    width: 180px;
+    height: 180px;
+  }
+
+  .circleOuter {
+    width: 120px;
+    height: 120px;
+  }
+
+  .circleInner {
+    width: 80px;
+    height: 80px;
   }
 }
 
@@ -237,11 +294,21 @@
 .navLink:hover,
 .navLink.active {
   color: var(--gold);
+  animation: electric-glow 1.5s ease-in-out infinite alternate;
 }
 
 .navLink:hover::after,
 .navLink.active::after {
   width: 100%;
+}
+
+@keyframes electric-glow {
+  from {
+    text-shadow: 0 0 4px rgba(212, 175, 55, 0.4), 0 0 10px rgba(212, 175, 55, 0.2);
+  }
+  to {
+    text-shadow: 0 0 12px rgba(212, 175, 55, 0.8), 0 0 24px rgba(255, 255, 255, 0.6);
+  }
 }
 
 .mobileMenuBtn {
@@ -283,6 +350,7 @@
 }
 
 /* Hero Section */
+
 .heroSection {
   min-height: calc(100vh - 90px);
   display: flex;
@@ -291,11 +359,23 @@
   position: relative;
   padding: 60px;
   background: var(--background); /* ← Now white */
+  overflow: hidden;
+}
+
+.heroSection::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: url('/circuit-board.svg') center/cover no-repeat;
+  opacity: 0.06;
+  z-index: 0;
 }
 
 .heroContent {
   text-align: center;
   max-width: 900px;
+  position: relative;
+  z-index: 1;
 }
 
 .heroSubtitle {
@@ -1400,14 +1480,6 @@
 }
 
 /* ======== TRANSITION ANIMATIONS — FADE FROM PRELOADER TO PAGE ======== */
-
-/* Fade out preloader */
-.loaderContainer.fade-out {
-  opacity: 0;
-  pointer-events: none;
-  transform: scale(1.05); /* Slight zoom-out for cinematic feel */
-  transition: opacity 1.4s ease-out, transform 1.4s ease-out, background 1.4s ease-out;
-}
 
 /* Fade in main content after preloader */
 .main-container {


### PR DESCRIPTION
## Summary
- Animate loader with circuit-board path and tagline that fades to content
- Add subtle circuit-board background and improved copy to hero section
- Include reusable circuit-board SVG asset for branding

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(requires interactive setup; no lint run)*
- `npm run build` *(passes with warnings)*

------
https://chatgpt.com/codex/tasks/task_b_68c5162c2cd08329acbbb0f0a311283f